### PR TITLE
docker-compose updates, Ubuntu 16.04 Setup Notes

### DIFF
--- a/Dockerfile-ldap
+++ b/Dockerfile-ldap
@@ -8,9 +8,10 @@ COPY ./hostname ./hack/hostname
 RUN chmod +x ./hack/hostname
 
 COPY ./ldap/install-ldap ./install-ldap
+RUN tar xfz release-zimbra-8.tgz
 RUN export PATH=/tmp/hack:$PATH && \
     echo "`hostname -i` `hostname --fqdn`" >> /etc/hosts && \
-    cd /tmp/BUILDS/*/*/*/zm-build/zcs-* && \
+    cd /tmp/zcs-* && \
     ./install.sh -s < /tmp/install-ldap
 
 COPY ./zmc-config ./zmc-config

--- a/Dockerfile-ldap
+++ b/Dockerfile-ldap
@@ -21,7 +21,7 @@ RUN cat ./zmc-config ./ldap-config | sed '/^\s*$/d' >> ./config
 WORKDIR /opt/zimbra
 COPY ./ldap/ldap-entrypoint ./ldap-entrypoint
 RUN chmod +x ./ldap-entrypoint && \
-    mv /tmp/healthcheck.py ./healthcheck.py
+    mv /zimbra/healthcheck.py ./healthcheck.py
 
 ENTRYPOINT ./ldap-entrypoint
 EXPOSE 22 25 465 587 110 143 993 995 80 443 8080 8443 7071

--- a/Dockerfile-mailbox
+++ b/Dockerfile-mailbox
@@ -8,9 +8,10 @@ COPY ./hostname ./hack/hostname
 RUN chmod +x ./hack/hostname
 
 COPY ./mailbox/install-mailbox ./install-mailbox
+RUN tar xfz release-zimbra-8.tgz
 RUN export PATH=/tmp/hack:$PATH && \
     echo "`hostname -i` `hostname --fqdn`" >> /etc/hosts && \
-    cd /tmp/BUILDS/*/*/*/zm-build/zcs-* && \
+    cd /tmp/zcs-* && \
     ./install.sh -s < /tmp/install-mailbox
 
 COPY ./zmc-config ./zmc-config

--- a/Dockerfile-mailbox
+++ b/Dockerfile-mailbox
@@ -21,7 +21,7 @@ RUN cat ./zmc-config ./mailbox-config | sed '/^\s*$/d' >> ./config
 WORKDIR /opt/zimbra
 COPY ./mailbox/mailbox-entrypoint ./mailbox-entrypoint
 RUN chmod +x ./mailbox-entrypoint && \
-    mv /tmp/healthcheck.py ./healthcheck.py
+    mv /zimbra/healthcheck.py ./healthcheck.py
 
 ENTRYPOINT ./mailbox-entrypoint
 EXPOSE 22 25 465 587 110 143 993 995 80 443 8080 8443 7071

--- a/Dockerfile-mta
+++ b/Dockerfile-mta
@@ -8,9 +8,10 @@ COPY ./hostname ./hack/hostname
 RUN chmod +x ./hack/hostname
 
 COPY ./mta/install-mta ./install-mta
+RUN tar xfz release-zimbra-8.tgz
 RUN export PATH=/tmp/hack:$PATH && \
     echo "`hostname -i` `hostname --fqdn`" >> /etc/hosts && \
-    cd /tmp/BUILDS/*/*/*/zm-build/zcs-* && \
+    cd /tmp/zcs-* && \
     ./install.sh -s < /tmp/install-mta
 
 COPY ./zmc-config ./zmc-config

--- a/Dockerfile-mta
+++ b/Dockerfile-mta
@@ -21,7 +21,7 @@ RUN cat ./zmc-config ./mta-config | sed '/^\s*$/d' >> ./config
 WORKDIR /opt/zimbra
 COPY ./mta/mta-entrypoint ./mta-entrypoint
 RUN chmod +x ./mta-entrypoint && \
-    mv /tmp/healthcheck.py ./healthcheck.py
+    mv /zimbra/healthcheck.py ./healthcheck.py
 
 ENTRYPOINT ./mta-entrypoint
 EXPOSE 22 25 465 587 110 143 993 995 80 443 8080 8443 7071

--- a/Dockerfile-mysql
+++ b/Dockerfile-mysql
@@ -8,9 +8,10 @@ COPY ./hostname ./hack/hostname
 RUN chmod +x ./hack/hostname
 
 COPY ./mysql/install ./install
+RUN tar xfz release-zimbra-8.tgz
 RUN export PATH=/tmp/hack:$PATH && \
     echo "`hostname -i` `hostname --fqdn`" >> /etc/hosts && \
-    cd /tmp/BUILDS/*/*/*/zm-build/zcs-* && \
+    cd /tmp/zcs-* && \
     ./install.sh -s < /tmp/install
 
 COPY ./zmc-config ./zmc-config

--- a/Dockerfile-proxy
+++ b/Dockerfile-proxy
@@ -8,9 +8,10 @@ COPY ./hostname ./hack/hostname
 RUN chmod +x ./hack/hostname
 
 COPY ./proxy/install-proxy ./install-proxy
+RUN tar xfz release-zimbra-8.tgz
 RUN export PATH=/tmp/hack:$PATH && \
     echo "`hostname -i` `hostname --fqdn`" >> /etc/hosts && \
-    cd /tmp/BUILDS/*/*/*/zm-build/zcs-* && \
+    cd /tmp/zcs-* && \
     ./install.sh -s < /tmp/install-proxy
 
 COPY ./zmc-config ./zmc-config

--- a/Dockerfile-proxy
+++ b/Dockerfile-proxy
@@ -21,7 +21,7 @@ RUN cat ./zmc-config ./proxy-config | sed '/^\s*$/d' >> ./config
 WORKDIR /opt/zimbra
 COPY ./proxy/proxy-entrypoint ./proxy-entrypoint
 RUN chmod +x ./proxy-entrypoint && \
-    mv /tmp/healthcheck.py ./healthcheck.py
+    mv /zimbra/healthcheck.py ./healthcheck.py
 
 ENTRYPOINT ./proxy-entrypoint
 EXPOSE 22 25 465 587 110 143 993 995 80 443 8080 8443 7071

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Zimbra Collaboration Suite Docker Containers
 
-## Setup
+## Setup (MacOS)
 If you do not have access to the f9teams organization on Docker Hub, @spoon16 in Slack with your Docker Hub username.
 
 `docker login --username <your docker hub username>`
@@ -52,6 +52,50 @@ cd ~/Library/Containers/com.docker.docker/Data/com.docker.driver.amd64-linux/
 rm Docker.qcow2
 qemu-img create -f qcow2 ./Docker.qcow2 128G
 ```
+
+## Setup (Ubuntu 16.04)
+
+Add the GPG key for official Docker repository, so you can install the latest version:
+
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+
+Add the Docker repository to APT sources:
+
+    sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+
+Update the package database with the Docker packages from the newly added repo:
+
+    sudo apt-get update
+
+Make sure you are about to install from the Docker repo instead of the default Ubuntu 16.04 repo.
+
+    apt-cache policy docker-ce
+
+Install Docker.
+
+    sudo apt-get install -y docker-ce
+
+Verify it is running:
+
+    sudo systemctl status docker
+    ● docker.service - Docker Application Container Engine
+       Loaded: loaded (/lib/systemd/system/docker.service; enabled; vendor preset: enabled)
+       Active: active (running) since Tue 2017-08-01 14:38:48 CDT; 5s ago
+         Docs: https://docs.docker.com
+     Main PID: 6430 (dockerd)
+
+Add (your) host-machine user to the docker group so you don't have to use
+`sudo` with Docker commands. You will have to log out and back in for it to
+take effect.
+
+    sudo usermod -aG docker ${USER}
+
+Install docker-compose:
+
+    sudo mkdir -p /usr/local/bin
+    sudo chown ${USER}:${USER} /usr/local/bin
+    curl -L https://github.com/docker/compose/releases/download/1.15.0/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
+    sudo chmod +x /usr/local/bin/docker-compose
 
 ## Starting a Zimbra Cluster
 


### PR DESCRIPTION
Found that the `master` branches of `zm-docker-base` and `zm-docker` were a little out of sync.  Updated the `Dockerfile-*` as needed.  Added Ubuntu 16.04 setup instructions to the README.