### PR TITLE
Use pre-extracted ZCS build from zmc-build

### DIFF
--- a/Dockerfile-ldap
+++ b/Dockerfile-ldap
@@ -8,10 +8,9 @@ COPY ./hostname ./hack/hostname
 RUN chmod +x ./hack/hostname
 
 COPY ./ldap/install-ldap ./install-ldap
-RUN tar xfz release-zimbra-8.tgz
 RUN export PATH=/tmp/hack:$PATH && \
     echo "`hostname -i` `hostname --fqdn`" >> /etc/hosts && \
-    cd /tmp/zcs-* && \
+    cd /zimbra/release && \
     ./install.sh -s < /tmp/install-ldap
 
 COPY ./zmc-config ./zmc-config

--- a/Dockerfile-mailbox
+++ b/Dockerfile-mailbox
@@ -8,10 +8,9 @@ COPY ./hostname ./hack/hostname
 RUN chmod +x ./hack/hostname
 
 COPY ./mailbox/install-mailbox ./install-mailbox
-RUN tar xfz release-zimbra-8.tgz
 RUN export PATH=/tmp/hack:$PATH && \
     echo "`hostname -i` `hostname --fqdn`" >> /etc/hosts && \
-    cd /tmp/zcs-* && \
+    cd /zimbra/release && \
     ./install.sh -s < /tmp/install-mailbox
 
 COPY ./zmc-config ./zmc-config

--- a/Dockerfile-mta
+++ b/Dockerfile-mta
@@ -8,10 +8,9 @@ COPY ./hostname ./hack/hostname
 RUN chmod +x ./hack/hostname
 
 COPY ./mta/install-mta ./install-mta
-RUN tar xfz release-zimbra-8.tgz
 RUN export PATH=/tmp/hack:$PATH && \
     echo "`hostname -i` `hostname --fqdn`" >> /etc/hosts && \
-    cd /tmp/zcs-* && \
+    cd /zimbra/release && \
     ./install.sh -s < /tmp/install-mta
 
 COPY ./zmc-config ./zmc-config

--- a/Dockerfile-mysql
+++ b/Dockerfile-mysql
@@ -8,10 +8,9 @@ COPY ./hostname ./hack/hostname
 RUN chmod +x ./hack/hostname
 
 COPY ./mysql/install ./install
-RUN tar xfz release-zimbra-8.tgz
 RUN export PATH=/tmp/hack:$PATH && \
     echo "`hostname -i` `hostname --fqdn`" >> /etc/hosts && \
-    cd /tmp/zcs-* && \
+    cd /zimbra/release && \
     ./install.sh -s < /tmp/install
 
 COPY ./zmc-config ./zmc-config

--- a/Dockerfile-proxy
+++ b/Dockerfile-proxy
@@ -8,10 +8,9 @@ COPY ./hostname ./hack/hostname
 RUN chmod +x ./hack/hostname
 
 COPY ./proxy/install-proxy ./install-proxy
-RUN tar xfz release-zimbra-8.tgz
 RUN export PATH=/tmp/hack:$PATH && \
     echo "`hostname -i` `hostname --fqdn`" >> /etc/hosts && \
-    cd /tmp/zcs-* && \
+    cd /zimbra/release && \
     ./install.sh -s < /tmp/install-proxy
 
 COPY ./zmc-config ./zmc-config


### PR DESCRIPTION
The ZCS build that is pulled down into `zmc-build` is already extracted to `/zimbra/release` so no need to do that when deploying the individual `zmc-*` containers.