### PR TITLE
Bugfix/ZCS-3981 Add zimbra_ldap_userdn configuration 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ CONFIGS += .config/zimbra_ldap_userdn
 
 .config/zimbra_ldap_userdn: .config/zimbra_ldap_userdn
 	@echo uid=zimbra,cn=admins,cn=zimbra > $@
-	@echo reated default $@ : $$(cat $@)
+	@echo Created default $@ : $$(cat $@)
 
 init-configs: $(CONFIGS)
 	@echo All Configs Created!

--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,7 @@ CONFIGS += .config/ham_account_name
 CONFIGS += .config/virus_quarantine_account_name
 CONFIGS += .config/gal_sync_account_name
 CONFIGS += .config/av_notify_email
+CONFIGS += .config/zimbra_ldap_userdn
 
 .config/.init:
 	mkdir .config
@@ -155,6 +156,10 @@ CONFIGS += .config/av_notify_email
 .config/av_notify_email: .config/domain_name
 	@echo admin@$$(cat $<) > $@
 	@echo Created default $@ : $$(cat $@)
+
+.config/zimbra_ldap_userdn: .config/zimbra_ldap_userdn
+	@echo uid=zimbra,cn=admins,cn=zimbra > $@
+	@echo reated default $@ : $$(cat $@)
 
 init-configs: $(CONFIGS)
 	@echo All Configs Created!

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ If desired, edit these files in the `.config` directory and enter your preferred
   - `ham_account_name`
   - `spam_account_name`
   - `virus_quarantine_account_name`
+  - `zimbra_ldap_userdn`
 
 
 ## Deploying the Stack

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
       - ${LOCAL_SRC_DIR}:/code
     configs:
       - av_notify_email
+      - zimbra_ldap_userdn
     secrets:
       - ca.key
       - ca.pem
@@ -210,6 +211,8 @@ configs:
      file: ./.config/virus_quarantine_account_name
    gal_sync_account_name:
      file: ./.config/gal_sync_account_name
+   zimbra_ldap_userdn:
+     file: ./.config/zimbra_ldap_userdn
 
 volumes:
   blobvolume: {}

--- a/mta/entry-point.pl
+++ b/mta/entry-point.pl
@@ -23,10 +23,13 @@ my $ENTRY_PID = $$;
 ## SECRETS AND CONFIGS #################################
 
 my $AV_NOTIFY_EMAIL       = Config("av_notify_email");
+my $ZIMBRA_LDAP_USERDN    = Config("zimbra_ldap_userdn");
+
 my $LDAP_MASTER_PASSWORD  = Secret("ldap.master_password");
 my $LDAP_ROOT_PASSWORD    = Secret("ldap.root_password");
 my $LDAP_POSTFIX_PASSWORD = Secret("ldap.postfix_password");
 my $LDAP_AMAVIS_PASSWORD  = Secret("ldap.amavis_password");
+
 
 ## CONNECTIONS TO OTHER HOSTS ##########################
 
@@ -71,6 +74,7 @@ EntryExec(
                zmtrainsa_cleanup_host        => "true",
                ldap_port                     => $LDAP_PORT,
                ldap_host                     => $LDAP_HOST,
+               zimbra_ldap_userdn            => $ZIMBRA_LDAP_USERDN,
             },
          };
       },


### PR DESCRIPTION
zmdkimkeyutil fails to run on MTA with error "Invalid credentials" since the value of zimbra_ldap_userdn was missing in localconfig.xml. Added a new config in Makefile to fix this.
 
**Testing:**

```
zimbra@zmc-mta:~$ ./libexec/zmdkimkeyutil -a -d test.com
DKIM Data added to LDAP for domain test.com with selector 2325E226-F9B7-11E7-B7C2-9BD5EEF5163F
Public signature to enter into DNS:
2325E226-F9B7-11E7-B7C2-9BD5EEF5163F._domainkey	IN	TXT	( "v=DKIM1; k=rsa; "
	  "p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA15yxSpkS9qHvz53fHA7EYpaVYsZb6V7RAiCgMQln8Va5ISrclih++zVLFTBqwx4BcUZFylEZRtlCDaYECD7xhxzM8YADter9nETzCJ06TX7FJsdxN6gj3gb50+gmDdk9eJ0cynVBqjamvhHBsboSf7RVm4ZeMKrlsw6DJ5/+3r8cBAmdkkYpmTbneCK25IAHv8r5C7KQ8Op1C/"
	  "X8FX+2jzoukzeSOFTcDZMlMEq9eESubRpC5wpU1U4XipkTsGykUWEv7/PCz7uMg1jALdaUSr69/HKdywqzOotJ0DVyWme8nRgJvEJ0iQtV3z+DFXoCzwXsRuuD/8kzWs2S6Ug9WQIDAQAB" )  ; ----- DKIM key 2325E226-F9B7-11E7-B7C2-9BD5EEF5163F for test.com
```