### PR TITLE
feature/ZCS-4029 SOAP Harness pre-req updates

### DIFF
--- a/mailbox/Dockerfile
+++ b/mailbox/Dockerfile
@@ -7,6 +7,8 @@ RUN apt-get install -y zimbra-store
 RUN apt-get install -y zimbra-imapd
 RUN apt-get install -y zimbra-chat
 RUN apt-get install -y zimbra-drive
+RUN apt-get install -y zimbra-spell
+RUN apt-get install -y zimbra-apache
 
 # special post install fixes
 RUN rm -f /opt/zimbra/common/sbin/mysqld                                                           # FIXME: mysql.server should not be required with zimbra-store

--- a/mailbox/entry-point.pl
+++ b/mailbox/entry-point.pl
@@ -211,8 +211,8 @@ EntryExec(
                $THIS_HOST => {
                   zimbraIPMode                    => "ipv4",
                   zimbraSpellCheckURL             => "http://$THIS_HOST:7780/aspell.php",
-                  zimbraServiceInstalled          => [ "stats", "mailbox", "imapd" ],
-                  zimbraServiceEnabled            => [ "stats", "mailbox", "service", "imapd", "zimbra", "zimlet", "zimbraAdmin" ],
+                  zimbraServiceInstalled          => [ "stats", "mailbox", "imapd", "spell" ],
+                  zimbraServiceEnabled            => [ "stats", "mailbox", "service", "imapd", "zimbra", "zimlet", "zimbraAdmin", "spell" ],
                   zimbraConvertdURL               => "http://$THIS_HOST:7047/convert",
                   zimbraAdminPort                 => $ADMIN_PORT,
                   zimbraAdminProxyPort            => $PROXY_ADMIN_PORT,

--- a/mta/entry-point.pl
+++ b/mta/entry-point.pl
@@ -138,6 +138,7 @@ EntryExec(
 
       # FIXME - requires LDAP
       #sub { { desc => "Updating IP Settings", exec => { args => ["/opt/zimbra/libexec/zmiptool"], }, }; },
+      sub { { desc => "Starting ssh-server", exec => { user => "root", args => [ "/usr/sbin/service", "ssh", "start" ], }, }; },
 
       # FIXME - requires LDAP
       sub { { desc => "Bringing up all services", exec => { args => [ "/opt/zimbra/bin/zmcontrol", "start" ], }, }; },


### PR DESCRIPTION
1. Enable `sshd` on the `MTA` service
2. Enable `zimbra-spell` on the `mailbox` service.