### PR TITLE
Make sure can find STAF even if done setup

### DIFF
--- a/test/init
+++ b/test/init
@@ -165,7 +165,6 @@ function setup {
       -e "s/HOSTNAME/${HOSTNAME}/" > /opt/qa/genesis/conf/genesis.conf
 
     # Fire up STAF
-    export PATH=/usr/local/staf/bin:$PATH
     echo "starting STAF. output to /opt/qa/logs/staf.log."
     # NOTE: will see this error if you are watching the logs:
     #       STAFProcess::processMonitorThread: Error opening /dev/tty, errno: 6
@@ -182,6 +181,8 @@ function setup {
     wait_for_staf "${mailbox_fqdn}"
     touch ${setup_complete_flag}
 }
+
+export PATH=/usr/local/staf/bin:$PATH
 
 if [ ! -f ${setup_complete_flag} ]; then
     setup


### PR DESCRIPTION
If you try and run init using docker exec afterwards, it doesn't run.