### PR TITLE
ZCS-4779 Create Redis image for use with zm-docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,16 @@
 version: '3.3'
 
 services:
-  redis:
-    image: library/redis
+  zmc-redis:
+    image: '${DOCKER_REPO_NS}/zmc-redis:${DOCKER_BUILD_TAG}'
     hostname: redis
+    build:
+      context: "."
+      dockerfile: 'redis/Dockerfile'
+      args:
+        - BASE=4.0.9
+    volumes:
+      - /proc:/writable-proc
     deploy:
       mode: replicated
       replicas: 1
@@ -71,7 +78,7 @@ services:
          DOCKER_REPO_NS: '${DOCKER_REPO_NS}'
          DOCKER_BUILD_TAG: '${DOCKER_BUILD_TAG}'
     depends_on:
-      - redis
+      - zmc-redis
     deploy:
       mode: replicated
       replicas: 2

--- a/redis/Dockerfile
+++ b/redis/Dockerfile
@@ -1,0 +1,9 @@
+ARG BASE
+FROM redis:$BASE
+COPY redis/rc.local /etc/rc.local
+RUN chmod 755 /etc/rc.local
+COPY redis/entrypoint /entrypoint
+RUN chmod a+x /entrypoint
+
+ENTRYPOINT ["/entrypoint"]
+

--- a/redis/entrypoint
+++ b/redis/entrypoint
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Small entrypoint script that just updates somaxconn before starting docker.
+# NOTE: This setting is also in the rc.local file; however, I found that
+#       having it there alone did not cause the somaxconn value to be altered
+#       from its default value of 128.  There are some additional notes in
+#       that file as well that talk about the configuration that is
+#       required in the docker-compose.yml file.
+
+echo "entrypoint - updating somaxconn..."
+echo 1024 > /writable-proc/sys/net/core/somaxconn
+
+echo "entrypoint - starting redis..."
+/usr/local/bin/docker-entrypoint.sh redis-server

--- a/redis/rc.local
+++ b/redis/rc.local
@@ -1,0 +1,43 @@
+#!/bin/sh -e
+#
+# rc.local
+#
+# This script is executed at the end of each multiuser runlevel.
+# Make sure that the script will "exit 0" on success or any other
+# value on error.
+#
+# In order to enable or disable this script just change the execution
+# bits.
+#
+# By default this script does nothing.
+#
+# Notes:
+#
+# We need to make a couple of updates for Redis
+#
+# 1. Need to increase somaxconn above its default value of 128
+#    You cannot just do this:
+#      sysctl -w net.core.somaxconn=1024
+#    Also, because /proc is mounted read-only, you must 
+#    remount it as follows in the docker-compose.yml file and
+#    write changes to `/writable-proc` instead of `/proc`.
+#
+#    volumes:
+#      - /proc:/writable-proc
+#
+#    These constraints are not the same if you are deploying a single 
+#    container via `docker run...` or if you are deploying via
+#    `docker-compose up -d`.  Both of those methods have other
+#    alternatives that are not available when deploying into
+#    a swarm.
+#
+# 2. Need to disable THP (Transparent Huge Pages).
+
+# This is also done in the entrypoint script.  It
+# is included here in case we manually restart redis
+# on the container for some reason.
+echo 1024 > /writable-proc/sys/net/core/somaxconn
+# This does not need to be in the entrypoint script.
+echo never > /sys/kernel/mm/transparent_hugepage/enabled
+
+exit 0


### PR DESCRIPTION
## Summary

This change provides the following:

1. Disable Transparent Huge Pages (THP)
2. Increase the default `somaxconn` value from `128` to `1024`

Please see additional notes in the following files:

- `redis/rc.local`
- `redis/entrypoint`

## Notes

1. I found there were some differences in the techniques required to achieve the above two  objectives based on how an Image is being deployed. In fact they vary in the following three scenarios:

    * Deploy via `docker run ...`
    * Deploy via `docker-compose up -d`
    * Deploy via `docker stack deploy ...` (this is the scenario for `zm-docker`)

2. At some point in the future this process may be simplified somewhat.  There are some active open issues that, if worked and merged, would make it possible to do what this pull request does with simple updates to `docker-compose.yml`
3. I have not attempted to add a specific config file for Redis at this point.  That should be done as part of work done to create a Redis cluster.

## PR Updates

- [2018-04-13, 12:46 US/Central] Updated the PR commit to address comments and questions to date.