### PR TITLE
ZCS-4330: basic health check for mailbox service.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.3'
+version: '3.4'
 
 services:
   zmc-redis:
@@ -83,6 +83,12 @@ services:
     deploy:
       mode: replicated
       replicas: 2
+    healthcheck:
+      test: ["CMD-SHELL", "su - zimbra -c 'zmsoap -z PingRequest' | grep -e PingResponse"]
+      interval: 10s
+      timeout: 5s
+      retries: 2
+      start_period: 240s
     volumes:
       - ${LOCAL_SRC_DIR}:/code
       - blobvolume:/opt/zimbra/store


### PR DESCRIPTION
Added health check service with PingRequest on mailbox node.
Following command sends admin auth request followed by PingRequest to localhost.
zmsoap -z PingRequest
PingRequest is the light weight soap request for health check. 
Kept timeout 5s tested on my local setup. 
Health check frequency 10s, can be more aggressive depending on requirement.
start period 240s , It is working fine with 120s as well depending on environment. 

 