### PR TITLE
ZCS-4330 Fix zmc-proxy startup

### DIFF
--- a/common/Zimbra/DockerLib.pm
+++ b/common/Zimbra/DockerLib.pm
@@ -71,6 +71,19 @@ my %MAPPING = (
            foreach ( $a->{service} || (), @{ $a->{services} || [] } );
       },
    },
+   wait_for_service_to_resolve => {
+      desc => "Waiting for service to resolve...",
+      impl => sub {
+         my $svc = shift;
+         my $sleep = 5;   # seconds
+         my $total = 0;
+         while ( system("getent hosts ${svc} > /dev/null") != 0 ) {
+            print "Waiting for service ${svc} to resolve for ${sleep} seconds (Total wait time so far=${total} seconds)\n";
+            $total += $sleep;
+            sleep $sleep;
+         }
+      },
+   },
    exec => {
       desc => undef,
       impl => sub {

--- a/proxy/entry-point.pl
+++ b/proxy/entry-point.pl
@@ -156,6 +156,8 @@ EntryExec(
       # FIXME - requires LDAP
       #sub { { desc => "Updating IP Settings", exec => { args => ["/opt/zimbra/libexec/zmiptool"], }, }; },
 
+      sub { { wait_for_service_to_resolve => $MAILBOX_HOST, }; },
+
       # FIXME - requires LDAP
       sub { { desc => "Bringing up all services", exec => { args => [ "/opt/zimbra/bin/zmcontrol", "start" ], }, }; },
 


### PR DESCRIPTION
The addition of the `healthcheck` configuration in `docker-compose.yml` for  the *zmc-mailbox* service resulted in startup issues with  the *zmc-proxy* service.  In particular, when the entry-point script for the *zmc-proxy* service ran `zmcontrol start` the proxy was failing to start.  If I  manually logged  into the proxy service I could manually bring the proxy up via `zmproxyctl start`.

This problem was caused by a failure of DNS resolution for `zmc-mailbox` at the time that `zmcontrol start` was executed.

This pull request adds a new function to the `DockerLib.pm` common Perl module that will block until the provided service name can be resolved and wires it into the entry-point script for *zmc-proxy*.

Note that the following alternate techniques did *not* work:

1. Adding `depends_on: zmc-mailbox` clause to the proxy config.
2. Moving the `wait_for zmc-mailbox` function in  the proxy entry-point to before `zmcontrol start`.   There was an additional problem with using this as it is perfectly fine for the proxy to go ahead and start services *before* the mailbox services are fully initialized.

### 2018-04-25 Addressed pull request comments

Sample output:

	zm-docker_zmc-proxy.1.rs7iszfmjoxt@linuxkit-00155de2e013    | Waiting for service zmc-mailbox to resolve for 5 seconds (Total wait time so far=0 seconds)
	zm-docker_zmc-proxy.1.rs7iszfmjoxt@linuxkit-00155de2e013    | Waiting for service zmc-mailbox to resolve for 5 seconds (Total wait time so far=5 seconds)
	zm-docker_zmc-proxy.1.rs7iszfmjoxt@linuxkit-00155de2e013    | Waiting for service zmc-mailbox to resolve for 5 seconds (Total wait time so far=10 seconds)
	zm-docker_zmc-proxy.1.rs7iszfmjoxt@linuxkit-00155de2e013    | Waiting for service zmc-mailbox to resolve for 5 seconds (Total wait time so far=15 seconds)
	zm-docker_zmc-proxy.1.rs7iszfmjoxt@linuxkit-00155de2e013    | Waiting for service zmc-mailbox to resolve for 5 seconds (Total wait time so far=20 seconds)
	zm-docker_zmc-proxy.1.rs7iszfmjoxt@linuxkit-00155de2e013    | Waiting for service zmc-mailbox to resolve for 5 seconds (Total wait time so far=25 seconds)
	zm-docker_zmc-proxy.1.rs7iszfmjoxt@linuxkit-00155de2e013    | Waiting for service zmc-mailbox to resolve for 5 seconds (Total wait time so far=30 seconds)
	zm-docker_zmc-proxy.1.rs7iszfmjoxt@linuxkit-00155de2e013    | Waiting for service zmc-mailbox to resolve for 5 seconds (Total wait time so far=35 seconds)
	zm-docker_zmc-proxy.1.rs7iszfmjoxt@linuxkit-00155de2e013    | Waiting for service zmc-mailbox to resolve for 5 seconds (Total wait time so far=40 seconds)
	zm-docker_zmc-proxy.1.rs7iszfmjoxt@linuxkit-00155de2e013    | Waiting for service zmc-mailbox to resolve for 5 seconds (Total wait time so far=45 seconds)
	zm-docker_zmc-proxy.1.rs7iszfmjoxt@linuxkit-00155de2e013    | Waiting for service zmc-mailbox to resolve for 5 seconds (Total wait time so far=50 seconds)
	zm-docker_zmc-proxy.1.rs7iszfmjoxt@linuxkit-00155de2e013    | 2018-04-25 13:51:50 +0000 :: zmc-proxy  :: END        :: Waiting for service to resolve...                  :: 
	00:00:59 :: 00:01:47
	zm-docker_zmc-proxy.1.rs7iszfmjoxt@linuxkit-00155de2e013    | 2018-04-25 13:51:50 +0000 :: zmc-proxy  :: BEGIN      :: Bringing up all services                           :: 
	00:00:00 :: 00:01:47
	zm-docker_zmc-proxy.1.rs7iszfmjoxt@linuxkit-00155de2e013    | Host zmc-proxy
	zm-docker_zmc-proxy.1.rs7iszfmjoxt@linuxkit-00155de2e013    |   Starting zmconfigd...Done.
	zm-docker_zmc-proxy.1.rs7iszfmjoxt@linuxkit-00155de2e013    |   Starting memcached...Done.
	zm-docker_zmc-proxy.1.rs7iszfmjoxt@linuxkit-00155de2e013    |   Starting proxy...Done.
	zm-docker_zmc-proxy.1.rs7iszfmjoxt@linuxkit-00155de2e013    |   Starting stats...Done.
	zm-docker_zmc-proxy.1.rs7iszfmjoxt@linuxkit-00155de2e013    | 2018-04-25 13:52:04 +0000 :: zmc-proxy  :: END        :: Bringing up all services                           :: 

**Note:** Will rebase and fixup the second commit before merging pull request.